### PR TITLE
Update project README and live demo details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,32 @@
 # FocusFlow
 
-FocusFlow is an adaptive planner that turns deadlines, fixed commitments, energy
-patterns, and lifestyle goals into a realistic weekly schedule. A constraint-aware
-planner keeps schedules feasible, while a lightweight machine-learning model learns
-which study blocks each user is most likely to complete.
+FocusFlow is an AI-assisted planner that turns tasks, deadlines, recurring
+commitments, energy patterns, and lifestyle goals into a realistic calendar.
+Its constraint-aware scheduling engine protects fixed commitments and healthy
+routines while a lightweight machine-learning model learns when each user is
+most likely to complete focused work.
+
+**Live web app:** [focusflow-web-azure.vercel.app](https://focusflow-web-azure.vercel.app)
+
+## Features
+
+- Synchronized accounts, tasks, preferences, and plans across web and mobile
+- Recurring tasks and weekly fixed commitments
+- Automatic 7- or 14-day planning around deadlines and existing commitments
+- Day, three-day, and week calendar views with readable event details
+- Protected breaks, exercise, leisure, lunch, and dinner scheduling
+- User-controlled day boundaries, focus duration, energy levels, and 12/24-hour time
+- Completion feedback that influences future scheduling recommendations
+- Dark, responsive React web interface and an Expo-powered React Native client
+
+## How scheduling works
+
+The Flask scheduling service combines hard constraints with a completion-scoring
+model. Fixed commitments and locked blocks are placed first. Candidate focus
+slots are then ranked using task priority, difficulty, deadline pressure,
+preferred study time, energy levels, workload balance, and the user's historical
+completion pattern. The result remains explainable: every calendar block includes
+a reason for its placement.
 
 ## Architecture
 
@@ -13,7 +36,11 @@ which study blocks each user is most likely to complete.
 | Mobile | React Native, Expo Router, TypeScript |
 | API | Node.js, Express, MongoDB |
 | Scheduling | Python, Flask, scikit-learn |
-| Deployment | Vercel Hobby, MongoDB Atlas, Expo EAS |
+| Deployment | Vercel Hobby, MongoDB Atlas, Expo/EAS |
+
+The web client, Express API, and Flask scheduler run as separate Vercel projects.
+MongoDB Atlas provides the shared database, and Expo is used for mobile development
+and installable Android builds.
 
 ```text
 apps/web                 responsive browser application
@@ -25,14 +52,56 @@ services/scheduler       constraint-aware ML scheduling service
 
 ## Local development
 
-Prerequisites: Node.js 22+, npm 10+, Python 3.11+, and MongoDB.
+Prerequisites: Node.js 22+, npm 10+, and Python 3.11+. A local MongoDB install
+is not required for the default development workflow.
 
-1. Copy `.env.example` to `.env` and replace the development secrets.
-2. Run `npm install`.
-3. Create a Python virtual environment and install
-   `services/scheduler/requirements-dev.txt`.
-4. Start Flask with `npm run dev:scheduler`.
-5. Start the API and clients with `npm run dev`.
+From the repository root in PowerShell:
 
-More detailed setup and deployment documentation will be added as the MVP is
-completed.
+```powershell
+npm install
+py -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r services\scheduler\requirements-dev.txt
+npm run dev
+```
+
+Open `http://localhost:5173`. The command starts the web app, API, scheduler,
+and an isolated in-memory MongoDB instance. Local accounts and data reset when
+the command stops, so local testing cannot alter the deployed Atlas database.
+
+To run the mobile app, leave `npm run dev` running and use a second terminal:
+
+```powershell
+npm run dev:mobile
+```
+
+Expo on a physical phone needs `EXPO_PUBLIC_API_URL` set to the computer's LAN
+address. FocusFlow detects the LAN address from Expo automatically; use
+`EXPO_PUBLIC_API_URL` only when you need to override it.
+
+### Expo Go on an Android phone
+
+FocusFlow uses Expo SDK 57. During Expo's SDK 57 transition, the Play Store
+version of Expo Go still targets SDK 54. Download Expo's matching Android client:
+
+```powershell
+cd apps\mobile
+npx expo-go download android 57
+```
+
+Install the downloaded APK on the phone, allowing installation from the browser
+or file manager when Android asks. If Android reports that the app cannot be
+installed, uninstall the Play Store copy of Expo Go first and retry the APK.
+Then leave `npm run dev` running, start `npm run dev:mobile` in a second
+terminal, and scan its QR code while the phone and computer are on the same
+network.
+
+Expo Go does not load FocusFlow's notification module on Android because recent
+Expo Go clients do not support remote push notifications. The planner still
+works there; notification scheduling is enabled in FocusFlow development and
+standalone builds.
+
+## Deployment
+
+The production setup is designed to stay within free tiers for a personal MVP.
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the MongoDB Atlas, Vercel, and
+Expo setup.


### PR DESCRIPTION
## What changed

- adds the production web URL near the top of the README
- documents the current web and mobile feature set
- explains the constraint-aware ML scheduling approach
- updates the architecture and free-tier deployment overview
- expands local Expo and development setup instructions

## Why

The existing README described only the initial architecture and no longer reflected the working product or its deployed demo.

## Validation

- confirmed the production URL returns HTTP 200
- verified the README diff with `git diff --check`
- changed only `README.md` in this commit